### PR TITLE
Team experience share for Kill Entity source

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/KillEntityExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/KillEntityExperienceSource.java
@@ -140,8 +140,8 @@ public class KillEntityExperienceSource implements ExperienceSource {
 
 	private KillEntityExperienceSource(Calculation<Data> calculation, Boolean teamSharedExperience, AntiFarming antiFarming) {
 		this.calculation = calculation;
-        this.teamSharedExperience = teamSharedExperience;
-        this.antiFarming = antiFarming;
+		this.teamSharedExperience = teamSharedExperience;
+		this.antiFarming = antiFarming;
 	}
 
 	public static void register() {
@@ -241,9 +241,9 @@ public class KillEntityExperienceSource implements ExperienceSource {
 
 	public int applyTeamSharedExperience(ServerPlayerEntity player, int xpValue) {
 		var playerTeam = player.getScoreboardTeam();
-        if (!teamSharedExperience || playerTeam == null) {
-            return xpValue;
-        }
+		if (!teamSharedExperience || playerTeam == null) {
+			return xpValue;
+		}
 
 		List<ServerPlayerEntity> teammatesInRange = player.getServerWorld()
 				.getPlayers(p -> p.isTeamPlayer(playerTeam))
@@ -254,7 +254,7 @@ public class KillEntityExperienceSource implements ExperienceSource {
 		teammatesInRange.forEach(p -> SkillsAPI.updateExperienceSources(p, KillEntityExperienceSource.class, es -> sharedXpValue));
 
 		return sharedXpValue;
-    }
+	}
 
 	private static boolean isTeammateInShareRange(ServerPlayerEntity player, ServerPlayerEntity teammate) {
 		return player.getPos().distanceTo(teammate.getPos()) <= MAX_TEAMMATE_SHARE_DISTANCE;

--- a/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/KillEntityExperienceSource.java
+++ b/Common/src/main/java/net/puffish/skillsmod/experience/source/builtin/KillEntityExperienceSource.java
@@ -250,7 +250,7 @@ public class KillEntityExperienceSource implements ExperienceSource {
 				.stream().filter(p -> p != player && isTeammateInShareRange(player, p))
 				.collect(Collectors.toCollection(ArrayList::new));
 
-		int sharedXpValue = xpValue / teammatesInRange.size();
+		int sharedXpValue = Math.min(xpValue / teammatesInRange.size(), 1);
 		teammatesInRange.forEach(p -> SkillsAPI.updateExperienceSources(p, KillEntityExperienceSource.class, es -> sharedXpValue));
 
 		return sharedXpValue;

--- a/Common/src/main/java/net/puffish/skillsmod/mixin/LivingEntityMixin.java
+++ b/Common/src/main/java/net/puffish/skillsmod/mixin/LivingEntityMixin.java
@@ -44,18 +44,17 @@ public abstract class LivingEntityMixin {
 			worldChunk.antiFarmingCleanupOutdated();
 			SkillsAPI.updateExperienceSources(player, experienceSource -> {
 				if (experienceSource instanceof KillEntityExperienceSource entityExperienceSource) {
-					if (entityExperienceSource
-							.getAntiFarming()
+					if (entityExperienceSource.getAntiFarming()
 							.map(worldChunk::antiFarmingAddAndCheck)
 							.orElse(true)
 					) {
-						return entityExperienceSource.getValue(player, entity, weapon, source, entityDroppedXp);
+						int xpValue = entityExperienceSource.getValue(player, entity, weapon, source, entityDroppedXp);
+						return entityExperienceSource.applyTeamSharedExperience(player, xpValue);
 					}
 				}
 				return 0;
 			});
 		}
-
 	}
 
 	@ModifyArg(method = "dropXp", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/ExperienceOrbEntity;spawn(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/util/math/Vec3d;I)V"), index = 2)


### PR DESCRIPTION
This is intended to use the vanilla team mechanic to find players within a set range to share experience from kills, if the option is enabled in the `kill_entity` experience source. `team_shared_experience` enables the feature when present, and configures the max distance in which to share experience between the attacking player and their teammates.

```
{
	"type": "puffish_skills:kill_entity",
	"data": {
		"variables": {
			"dropped_xp": {
				"operations": [
					{
						"type": "dropped_experience"
					}
				]
			},
			"max_health": {
				"operations": [
					{
						"type": "killed_living_entity"
					},
					{
						"type": "max_health"
					}
				]
			}
		},
		"experience": [
			{
				"expression": "dropped_xp + max_health / 20"
			}
		],
                "team_shared_experience": {
                        "max_share_distance": 100
                },
		"anti_farming": {
			"limit_per_chunk": 15,
			"reset_after_seconds": 300
		}
	}
}
```

Experience is shared evenly between all team members in range (including the player who got the final blow), but provide a minimum of 1 xp to all eligible team members.

Additionally, added `is_on_team` as a supported predicate if a user wishes to leverage this in their operations or experience expression.

I opted to not change the parameters or logic around the `anti_farming` behavior, because there is likely no net gain for someone to alternate killing blows while in a team (and sharing the xp) vs normal xp gain while not in a team. The existing behavior should suffice.