### PR TITLE
Attach ServerPlayerEntity to events. Add new reset skill event.

### DIFF
--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -88,10 +88,13 @@ public class SkillsMod {
 	public static final int MAX_CONFIG_VERSION = 3;
 
 	public static final Event<Events.SkillUnlock> SKILL_UNLOCK = Event.create(
-			c -> (categoryId, skillId) -> c.forEach(e -> e.onSkillUnlock(categoryId, skillId))
+			c -> (player, categoryId, skillId) -> c.forEach(e -> e.onSkillUnlock(player, categoryId, skillId))
 	);
 	public static final Event<Events.SkillLock> SKILL_LOCK = Event.create(
-			c -> (categoryId, skillId) -> c.forEach(e -> e.onSkillLock(categoryId, skillId))
+			c -> (player, categoryId, skillId) -> c.forEach(e -> e.onSkillLock(player, categoryId, skillId))
+	);
+	public static final Event<Events.SkillsReset> SKILLS_RESET = Event.create(
+			c -> (player, categoryId) -> c.forEach(e -> e.onSkillsReset(player, categoryId))
 	);
 
 	private static SkillsMod instance;
@@ -319,7 +322,7 @@ public class SkillsMod {
 						packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, true));
 						syncPoints(player, category, categoryData);
 					});
-					SKILL_UNLOCK.invoker().onSkillUnlock(categoryId, skillId);
+					SKILL_UNLOCK.invoker().onSkillUnlock(player, categoryId, skillId);
 					updateSkillRewards(player, category, categoryData, skill, true);
 				}
 			});
@@ -335,7 +338,7 @@ public class SkillsMod {
 					packetSender.send(player, new SkillUpdateOutPacket(categoryId, skillId, false));
 					syncPoints(player, category, categoryData);
 				});
-				SKILL_LOCK.invoker().onSkillLock(categoryId, skillId);
+				SKILL_LOCK.invoker().onSkillLock(player, categoryId, skillId);
 				updateSkillRewards(player, category, categoryData, skill, false);
 			});
 		});
@@ -347,6 +350,7 @@ public class SkillsMod {
 			categoryData.resetSkills();
 			updateRewards(player, category, categoryData);
 			showCategory(player, category, categoryData);
+			SKILLS_RESET.invoker().onSkillsReset(player, categoryId);
 		});
 	}
 

--- a/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
+++ b/Common/src/main/java/net/puffish/skillsmod/SkillsMod.java
@@ -93,9 +93,6 @@ public class SkillsMod {
 	public static final Event<Events.SkillLock> SKILL_LOCK = Event.create(
 			c -> (player, categoryId, skillId) -> c.forEach(e -> e.onSkillLock(player, categoryId, skillId))
 	);
-	public static final Event<Events.SkillsReset> SKILLS_RESET = Event.create(
-			c -> (player, categoryId) -> c.forEach(e -> e.onSkillsReset(player, categoryId))
-	);
 
 	private static SkillsMod instance;
 
@@ -347,10 +344,15 @@ public class SkillsMod {
 	public void resetSkills(ServerPlayerEntity player, Identifier categoryId) {
 		getCategory(categoryId).ifPresent(category -> {
 			var categoryData = getPlayerData(player).getOrCreateCategoryData(category);
+			var unlockedSkillIds = new ArrayList<>(categoryData.getUnlockedSkillIds());
+
 			categoryData.resetSkills();
 			updateRewards(player, category, categoryData);
 			showCategory(player, category, categoryData);
-			SKILLS_RESET.invoker().onSkillsReset(player, categoryId);
+
+			for (var skillId : unlockedSkillIds) {
+				SKILL_LOCK.invoker().onSkillLock(player, categoryId, skillId);
+			}
 		});
 	}
 

--- a/Common/src/main/java/net/puffish/skillsmod/api/Events.java
+++ b/Common/src/main/java/net/puffish/skillsmod/api/Events.java
@@ -1,15 +1,20 @@
 package net.puffish.skillsmod.api;
 
+import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 
 public class Events {
 
 	public interface SkillUnlock {
-		void onSkillUnlock(Identifier categoryId, String skillId);
+		void onSkillUnlock(ServerPlayerEntity player, Identifier categoryId, String skillId);
 	}
 
 	public interface SkillLock {
-		void onSkillLock(Identifier categoryId, String skillId);
+		void onSkillLock(ServerPlayerEntity player, Identifier categoryId, String skillId);
+	}
+
+	public interface SkillsReset {
+		void onSkillsReset(ServerPlayerEntity player, Identifier categoryId);
 	}
 
 }

--- a/Common/src/main/java/net/puffish/skillsmod/api/Events.java
+++ b/Common/src/main/java/net/puffish/skillsmod/api/Events.java
@@ -13,8 +13,4 @@ public class Events {
 		void onSkillLock(ServerPlayerEntity player, Identifier categoryId, String skillId);
 	}
 
-	public interface SkillsReset {
-		void onSkillsReset(ServerPlayerEntity player, Identifier categoryId);
-	}
-
 }

--- a/Common/src/main/java/net/puffish/skillsmod/api/SkillsAPI.java
+++ b/Common/src/main/java/net/puffish/skillsmod/api/SkillsAPI.java
@@ -30,10 +30,6 @@ public final class SkillsAPI {
 		SkillsMod.SKILL_LOCK.register(event);
 	}
 
-	public static void registerSkillsResetEvent(Events.SkillsReset event) {
-		SkillsMod.SKILLS_RESET.register(event);
-	}
-
 	public static void registerReward(Identifier key, RewardFactory factory) {
 		RewardRegistry.register(key, factory);
 	}

--- a/Common/src/main/java/net/puffish/skillsmod/api/SkillsAPI.java
+++ b/Common/src/main/java/net/puffish/skillsmod/api/SkillsAPI.java
@@ -30,6 +30,10 @@ public final class SkillsAPI {
 		SkillsMod.SKILL_LOCK.register(event);
 	}
 
+	public static void registerSkillsResetEvent(Events.SkillsReset event) {
+		SkillsMod.SKILLS_RESET.register(event);
+	}
+
 	public static void registerReward(Identifier key, RewardFactory factory) {
 		RewardRegistry.register(key, factory);
 	}


### PR DESCRIPTION
I'm making a mod and noticed the events don't have any reference to the player that triggered them. That would help a lot for adding integrations with other mods, or at least my mod. Just thought I'd try to get this in if it makes sense to you.

This will cause mods that use these events to have to update to the new signature to keep working. I could also make new events and keep these ones to preserve backward compatibility.

```java
	public interface SkillUnlock {
		void onSkillUnlock(Identifier categoryId, String skillId);
	}

	public interface SkillLock {
		void onSkillLock(Identifier categoryId, String skillId);
	}

	public interface PlayerSkillUnlock {
		void onSkillUnlock(ServerPlayerEntity player, Identifier categoryId, String skillId);
	}

	public interface PlayerSkillLock {
		void onSkillLock(ServerPlayerEntity player, Identifier categoryId, String skillId);
	}

	public interface SkillsReset {
		void onSkillsReset(ServerPlayerEntity player, Identifier categoryId);
	}
```
Let me know, I'll do whatever you think is best!

I just made 2 compat mods for your mod, one that allows you to gate the use of items (damaging, using, equipping as armor / curios) behind needing a skill node. 
The next allows you to stop the use of spells in Iron's Spells and Spellbooks. It also allows you to take nodes to gain permanent access to a spell, with its own spell wheel and use button. Innate spells will behave as just player skills they can always access. https://www.curseforge.com/minecraft/mc-mods/irons-spellbooks-x-pufferfishs-skills
Iron's is live and working, but I can make some meaningful improvements with these events instead of polling for changes every x ticks. To keep the players skill nodes and spells in sync I don't have a great hook right now to do that, so I have to just poll and there might be a delay between taking a skill and the poll going off.

If you dont like adding the players to events, then just adding a playerless skill reset event would be great. Let me know and I can implement just that so I can hook into the reset flow.

Thanks!
